### PR TITLE
Fixing crashes

### DIFF
--- a/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
+++ b/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
@@ -7,7 +7,6 @@
 #include "KismetProceduralMeshLibrary.h"
 #include "ProceduralMeshComponent.h"
 
-#include "Regex.h"
 #include "Engine/StaticMesh.h"
 #include "Engine/StaticMeshActor.h"
 #include "Kismet/KismetMathLibrary.h"
@@ -36,7 +35,6 @@ void USlicingBladeComponent::BeginPlay()
 	
 }
 
-#pragma optimize("", off)
 void USlicingBladeComponent::OnBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor,
 	UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
 {
@@ -169,7 +167,6 @@ void USlicingBladeComponent::OnEndOverlap(UPrimitiveComponent* OverlappedComp, A
 
 	bLockOverlapEvents = false;
 }
-#pragma optimize("", on)
 
 void USlicingBladeComponent::SliceComponent(UPrimitiveComponent* CuttableComponent)
 {
@@ -270,7 +267,6 @@ void USlicingBladeComponent::SliceComponent(UPrimitiveComponent* CuttableCompone
 
 	// Broadcast destruction of object
 	OnObjectDestruction.Broadcast(CutComponent->GetAttachmentRootActor(), GetWorld()->GetTimeSeconds());
-
 }
 
 // Resets everything to the state the component was in before the dampening was set

--- a/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
+++ b/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
@@ -193,6 +193,9 @@ void USlicingBladeComponent::SliceComponent(UPrimitiveComponent* CuttableCompone
 	OutputProceduralMesh->ComponentTags = CuttableComponent->ComponentTags;
 	OutputProceduralMesh->SetLinearDamping(0.f);
 	OutputProceduralMesh->SetAngularDamping(0.f);
+	
+	// Hack
+	OutputProceduralMesh->AddWorldOffset(-1*SlicingObject->GetUpVector(), false);
 
 	CuttableComponent->SetLinearDamping(0.f);
 	CuttableComponent->SetAngularDamping(0.f);

--- a/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
+++ b/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
@@ -214,6 +214,8 @@ void USlicingBladeComponent::SliceComponent(UPrimitiveComponent* CuttableCompone
 	);
 	OutputProceduralMesh->SetGenerateOverlapEvents(true);
 	OutputProceduralMesh->SetEnableGravity(true);
+	OutputProceduralMesh->SetCollisionProfileName(CuttableComponent->GetCollisionProfileName());
+	OutputProceduralMesh->SetCollisionResponseToChannels(CuttableComponent->GetCollisionResponseToChannels());
 	OutputProceduralMesh->SetSimulatePhysics(CuttableComponent->IsSimulatingPhysics());
 	OutputProceduralMesh->ComponentTags = CuttableComponent->ComponentTags;
 	OutputProceduralMesh->SetLinearDamping(0.f);

--- a/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
+++ b/Source/USlicingLogic/Private/SlicingBladeComponent.cpp
@@ -225,9 +225,6 @@ void USlicingBladeComponent::SliceComponent(UPrimitiveComponent* CuttableCompone
 	OutputProceduralMesh->ComponentTags = CuttableComponent->ComponentTags;
 	OutputProceduralMesh->SetLinearDamping(0.f);
 	OutputProceduralMesh->SetAngularDamping(0.f);
-	
-	// Hack
-	OutputProceduralMesh->AddWorldOffset(-1*SlicingObject->GetUpVector(), false);
 
 	CuttableComponent->SetLinearDamping(0.f);
 	CuttableComponent->SetAngularDamping(0.f);
@@ -248,10 +245,6 @@ void USlicingBladeComponent::SliceComponent(UPrimitiveComponent* CuttableCompone
 		transformedObject->AttachToComponent(ParentComponent, attachRules);
 	}
 	
-	UE_LOG(LogTemp, Warning, TEXT("%s"), *transformedObject->GetName());
-	UE_LOG(LogTemp, Warning, TEXT("%s"), *newSlice->GetName());
-
-
 	FString ObjNameA = transformedObject->GetName();
 	FString ObjNameB = transformedObject->GetName();
 
@@ -262,11 +255,8 @@ void USlicingBladeComponent::SliceComponent(UPrimitiveComponent* CuttableCompone
 
 	transformedObject->Tags = OriginalTags;
 	transformedObject->Rename(*ObjNameA);
-	newSlice->Tags = OriginalTags;
+	newSlice->Tags = OriginalTags; 
 	newSlice->Rename(*ObjNameB);
-
-	UE_LOG(LogTemp, Warning, TEXT("%s"), *transformedObject->GetName());
-	UE_LOG(LogTemp, Warning, TEXT("%s"), *newSlice->GetName());
 
 	// Broadcat creation of Slice and transformed object
 	OnObjectCreation.Broadcast(transformedObject, newSlice, GetWorld()->GetTimeSeconds());

--- a/Source/USlicingLogic/Private/SlicingHelper.cpp
+++ b/Source/USlicingLogic/Private/SlicingHelper.cpp
@@ -50,7 +50,6 @@ AStaticMeshActor* FSlicingHelper::ConvertProceduralComponentToStaticMeshActor(
 	UStaticMesh* StaticMesh = GenerateStaticMesh(ProceduralMeshComponent, MaterialIndex);
 	// Set the static materials gotten from the old static mesh
 	StaticMesh->StaticMaterials = StaticMaterials;
-
 	AStaticMeshActor* StaticMeshActor = SpawnStaticMeshActor(ProceduralMeshComponent);
 
 	// Edit the StaticMeshComponent to have the same properties as the old ProceduralMeshComponent
@@ -60,7 +59,7 @@ AStaticMeshActor* FSlicingHelper::ConvertProceduralComponentToStaticMeshActor(
 
 	// Move actor's location to current mesh origin
 	StaticMeshActor->SetActorLocation(ProceduralMeshComponent->Bounds.Origin);
-	
+
 	// Remove the old component
 	ProceduralMeshComponent->DestroyComponent();
 
@@ -91,7 +90,7 @@ void FSlicingHelper::CorrectProperties(UPrimitiveComponent* NewComponent, UPrimi
 	NewComponent->RegisterComponent();
 	NewComponent->SetCollisionProfileName(FName("PhysicsActor"));
 	NewComponent->SetEnableGravity(true);
-	NewComponent->SetSimulatePhysics(true);
+	NewComponent->SetSimulatePhysics(OldComponent->IsSimulatingPhysics());
 	NewComponent->SetGenerateOverlapEvents(true);
 	NewComponent->ComponentTags = OldComponent->ComponentTags;
 }

--- a/Source/USlicingLogic/Private/SlicingHelper.cpp
+++ b/Source/USlicingLogic/Private/SlicingHelper.cpp
@@ -88,7 +88,8 @@ void FSlicingHelper::CorrectProperties(UPrimitiveComponent* NewComponent, UPrimi
 {
 	NewComponent->SetRelativeTransform(OldComponent->GetRelativeTransform());
 	NewComponent->RegisterComponent();
-	NewComponent->SetCollisionProfileName(FName("PhysicsActor"));
+	NewComponent->SetCollisionProfileName(OldComponent->GetCollisionProfileName());
+	NewComponent->SetCollisionResponseToChannels(OldComponent->GetCollisionResponseToChannels());
 	NewComponent->SetEnableGravity(true);
 	NewComponent->SetSimulatePhysics(OldComponent->IsSimulatingPhysics());
 	NewComponent->SetGenerateOverlapEvents(true);

--- a/Source/USlicingLogic/Public/SlicingBladeComponent.h
+++ b/Source/USlicingLogic/Public/SlicingBladeComponent.h
@@ -65,6 +65,9 @@ public:
 	FVector RelativeLocationToCutComponent;
 	FQuat RelativeRotationToCutComponent;
 
+	/**** Attached parent in case object was attached ****/
+	USceneComponent* ParentComponent;
+
 	/**** Implementation of the overlap events for slicing/aborting the slicing ****/
 	UFUNCTION()
 	void OnBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor,

--- a/Source/USlicingLogic/Public/SlicingBladeComponent.h
+++ b/Source/USlicingLogic/Public/SlicingBladeComponent.h
@@ -55,6 +55,8 @@ public:
 	//* Describes whether the cutting object is currently in the process of cutting a cuttable object
 	bool bIsCurrentlyCutting = false;
 
+	bool bLockOverlapEvents = false;
+
 	// The Constraints Component
 	UPhysicsConstraintComponent* ConstraintOne;
 

--- a/Source/USlicingLogic/Public/SlicingComponent.h
+++ b/Source/USlicingLogic/Public/SlicingComponent.h
@@ -32,6 +32,10 @@ public:
 	
 	//* The component of the object, the SlicingComponent is attached to
 	UStaticMeshComponent* SlicingObject;
-	//* The object that is currently being cut, but did not go through the slicing process yet
+
+	//* The component that is currently being cut, but did not go through the slicing process yet
 	UPrimitiveComponent* CutComponent;
+
+	//* The actor that is currently being cut, but did not go through the slicing process yet
+	AActor* CutActor;
 };


### PR DESCRIPTION
When the robot was using a knife for slicing new issued appeared. For example, If knife was slightly turned during cutting there was a crash. We were getting false overlap events, multiple overlap events at once, or they were going on infinite loops between begin overlap and end overlap.  So EndOverlapEvent is bind only after a BeginOverlapEvent but also they are block to ensure we don't have multiple events at the same time that tricks the slicing process. 

Besides that we also updated the properties being copied from the original mesh (gravity, physics simulation, collisions, attached parents and tags) and change the naming of the resulting actors to ensure they were always unique (we were getting repeated names after slicing the same object multiple times and it was messing with the TFPublisher)